### PR TITLE
Add support for options and make autoprefixer a peerDependency.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 
-var autoprefixer = require('autoprefixer');
 var minimatch = require('minimatch');
 
 
 function plugin (opts) {
   var opts = opts || {};
+  var autoprefixer = require('autoprefixer')(opts);
   return function (files, metalsmith, done) {
     var styles = Object.keys(files).filter(minimatch.filter("*.css", { matchBase: true }));
     styles.forEach(function (file, index, arr) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-autoprefixer-gustavnikolaj",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "metalsmith autoprefixer plugin",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,14 @@
     "url": "https://github.com/esundahl/metalsmith-autoprefixer/issues"
   },
   "homepage": "https://github.com/esundahl/metalsmith-autoprefixer",
+  "peerDependency": {
+    "autoprefixer": "*"
+  },
   "dependencies": {
-    "autoprefixer": "^1.1.20140327",
     "minimatch": "^0.2.14"
   },
   "devDependencies": {
+    "autoprefixer": "5.1.0",
     "mocha": "^1.18.2",
     "metalsmith": "^0.5.0",
     "assert-dir-equal": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "metalsmith-autoprefixer",
+  "name": "metalsmith-autoprefixer-gustavnikolaj",
   "version": "0.1.2",
   "description": "metalsmith autoprefixer plugin",
   "main": "lib/index.js",
@@ -15,6 +15,9 @@
     "autoprefixer"
   ],
   "author": "Erik Sundahl",
+  "contributors": [
+    "Gustav Nikolaj <gustavnikolaj@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/esundahl/metalsmith-autoprefixer/issues"

--- a/test/fixtures/basic/expected/style.css
+++ b/test/fixtures/basic/expected/style.css
@@ -2,13 +2,13 @@
   0% {
     opacity: 0;
     -webkit-transform: translateY(-2000px);
-    transform: translateY(-2000px);
+            transform: translateY(-2000px);
   }
 
   100% {
     opacity: 1;
     -webkit-transform: translateY(0);
-    transform: translateY(0);
+            transform: translateY(0);
   }
 }
 
@@ -16,17 +16,17 @@
   0% {
     opacity: 0;
     -webkit-transform: translateY(-2000px);
-    transform: translateY(-2000px);
+            transform: translateY(-2000px);
   }
 
   100% {
     opacity: 1;
     -webkit-transform: translateY(0);
-    transform: translateY(0);
+            transform: translateY(0);
   }
 }
 
 .fade-in-down-big {
   -webkit-animation-name: fade-in-down-big;
-  animation-name: fade-in-down-big;
+          animation-name: fade-in-down-big;
 }

--- a/test/fixtures/basic/expected/style.css
+++ b/test/fixtures/basic/expected/style.css
@@ -1,19 +1,3 @@
-
-body {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
-
 @-webkit-keyframes fade-in-down-big {
   0% {
     opacity: 0;

--- a/test/fixtures/basic/src/style.css
+++ b/test/fixtures/basic/src/style.css
@@ -1,10 +1,3 @@
-
-body {
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-}
-
 @keyframes fade-in-down-big {
   0% {
     opacity: 0;

--- a/test/fixtures/options/expected/style.css
+++ b/test/fixtures/options/expected/style.css
@@ -1,4 +1,4 @@
 h1 {
     -webkit-animation-name: 'foo';
-            animation-name: 'foo';
+    animation-name: 'foo';
 }

--- a/test/fixtures/options/expected/style.css
+++ b/test/fixtures/options/expected/style.css
@@ -1,0 +1,4 @@
+h1 {
+    -webkit-animation-name: 'foo';
+            animation-name: 'foo';
+}

--- a/test/fixtures/options/src/style.css
+++ b/test/fixtures/options/src/style.css
@@ -1,0 +1,3 @@
+h1 {
+    animation-name: 'foo';
+}

--- a/test/index.js
+++ b/test/index.js
@@ -6,10 +6,19 @@ var Metalsmith = require('metalsmith')
 describe('metalsmith-autoprefixer', function() {
   it('should add some prefixes', function(done){
     Metalsmith('test/fixtures/basic')
-      .use(autoprefixer())
+      .use(autoprefixer({ browsers: 'Chrome 30' }))
       .build(function(err) {
         if (err) return done(err)
         assertDir('test/fixtures/basic/expected', 'test/fixtures/basic/build')
+        return done(null)
+      })
+  })
+  it('should take options and propagate to autoprefixer', function(done){
+    Metalsmith('test/fixtures/options')
+      .use(autoprefixer({ browsers: 'Chrome 30', cascade: true }))
+      .build(function(err) {
+        if (err) return done(err)
+        assertDir('test/fixtures/options/expected', 'test/fixtures/options/build')
         return done(null)
       })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ describe('metalsmith-autoprefixer', function() {
   })
   it('should take options and propagate to autoprefixer', function(done){
     Metalsmith('test/fixtures/options')
-      .use(autoprefixer({ browsers: 'Chrome 30', cascade: true }))
+      .use(autoprefixer({ browsers: 'Chrome 30', cascade: false }))
       .build(function(err) {
         if (err) return done(err)
         assertDir('test/fixtures/options/expected', 'test/fixtures/options/build')


### PR DESCRIPTION
I added support for passing options through to autoprefixer. I needed to control the supported browsers manually.

I also changed the dependency on autoprefixer into a peer dependency. That fixes #1 too, as it will allow the user to bring the autoprefixer version they want. That solves the problem of autoprefixer getting outdated when updates to this project is not made the same instant a new version of autoprefixer is released.

I planned to do it as two seperate pull requests (as the merge commits reveal) but the default options changed in autoprefixer in the mean time, so I had to change the tests to make it merge without problems.

I fixed the version the tests use (by setting a development dependency) to autoprefixer 5.1.
