### PR TITLE
Fix console warning for deprecated process method.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,16 @@
 
 var minimatch = require('minimatch');
+var postcss   = require('postcss');
 
 
 function plugin (opts) {
   var opts = opts || {};
-  var autoprefixer = require('autoprefixer')(opts);
+  var autoprefixer = require('autoprefixer-core')(opts);
   return function (files, metalsmith, done) {
     var styles = Object.keys(files).filter(minimatch.filter("*.css", { matchBase: true }));
     setImmediate(done);
     styles.forEach(function (file, index, arr) {
-      files[file].contents = new Buffer(autoprefixer.process(files[file].contents.toString()).css);
+      files[file].contents = new Buffer(postcss([autoprefixer]).process(files[file].contents.toString()).css);
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "minimatch": "^2.0.1",
-    "autoprefixer-core": "^5.0.0",
+    "autoprefixer-core": "^5.2.1",
     "postcss": "^4.1.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "minimatch": "^2.0.1",
-    "autoprefixer": "^5.1.0"
+    "autoprefixer-core": "^5.0.0",
+    "postcss": "^4.1.11"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",


### PR DESCRIPTION
The warning appears due to updates to autoprefixer's API. Example:

![screen shot 2015-06-24 at 1 30 01 pm](https://cloud.githubusercontent.com/assets/859298/8322257/cb4d3c2a-1a75-11e5-9283-e5833705ab83.png)
