### PR TITLE
Dependency updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var postcss   = require('postcss');
 
 function plugin (opts) {
   var opts = opts || {};
-  var autoprefixer = require('autoprefixer-core')(opts);
+  var autoprefixer = require('autoprefixer')(opts);
   return function (files, metalsmith, done) {
     var styles = Object.keys(files).filter(minimatch.filter("*.css", { matchBase: true }));
     setImmediate(done);

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "autoprefixer": "*"
   },
   "dependencies": {
-    "minimatch": "^2.0.1",
-    "autoprefixer-core": "^5.2.1",
-    "postcss": "^4.1.11"
+    "autoprefixer": "^6.1.0",
+    "minimatch": "^3.0.0",
+    "postcss": "^5.0.12"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
-    "metalsmith": "^1.3.0",
+    "metalsmith": "^2.1.0",
     "mocha": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "peerDependency": {
     "autoprefixer": "*"
   },
+  "engines": {
+    "node": ">=4.2.0"
+  },
   "dependencies": {
     "autoprefixer": "^6.1.0",
     "minimatch": "^3.0.0",


### PR DESCRIPTION
- Replaced `autoprefixer-core`(deprecated) with `autoprefixer`
- Major node module version updates:
  - metalsmith
  - minimatch
  - postcss
